### PR TITLE
ENH: Add support for distinction between native-english and translated-to-english datasets with GDELT

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,4 +38,6 @@
   Removed datetime parsing
   Added unittests for events before 2013, gkg v1 before apr 1, etc.
 
+2017-07-18
+  Added support for translated-to-english datasets in gdelt v2 for gkg, events en mentions.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The GDELT Project advertises as the largest, most comprehensive, and highest res
 1.  Added geodataframe output; can be easily converted into a shapefile or [choropleth](https://en.wikipedia.org/wiki/Choropleth_map) visualization.
 2.  Added continuous integration testing for Windows, OSX, and Linux (Ubuntu)
 3.  Normalized columns output; export data with SQL ready columns (no special characters, all lowercase)
+4.  Choosing between the native-english or translated-to-english datasets from GDELT v2.
 
 ```python
 import gdelt

--- a/README.md
+++ b/README.md
@@ -98,13 +98,14 @@ Performance on 4 core, MacOS Sierra 10.12 with 16GB of RAM:
 ## `gdeltPyR` Parameters
 `gdeltPyR` provides access to 1.0 and 2.0 data.  Four basic parameters guide the query syntax:
 
-| **Name** | Description                                                                                                                                                                                                                                                       | Input Possibilities/Examples    |
-|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
-| version  | (integer)  - Selects the version of GDELT data to query; defaults to version 2.                                                                                                                                                                                   | 1 or 2                          |
-| date     | (string or list of strings) - Dates to query                                                                                                                                                                                                                      | "2016 10 23" or "2016 Oct 23"   |
-| coverage | (bool) - For GDELT 2.0, pulls every 15 minute interval in the dates passed in the 'date' parameter. Default coverage is False or None.  `gdeltPyR` will pull the latest 15 minute interval for the current day or the last 15 minute interval for a historic day. | True or False or None           |
-| tables   | (string) - The specific GDELT table to pull.  The default table is the 'events' table.  See the [GDELT documentation page for more information](http://gdeltproject.org/data.html#documentation)                                                                  | 'events' or 'mentions' or 'gkg' |
-| output   | (string) - The output type for the results                                                                 | 'json' or 'csv' or 'gpd' |
+| **Name**    | Description                                                                                                                                                                                                                                                       | Input Possibilities/Examples    |
+|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| version     | (integer)  - Selects the version of GDELT data to query; defaults to version 2.                                                                                                                                                                                   | 1 or 2                          |
+| date        | (string or list of strings) - Dates to query                                                                                                                                                                                                                      | "2016 10 23" or "2016 Oct 23"   |
+| coverage    | (bool) - For GDELT 2.0, pulls every 15 minute interval in the dates passed in the 'date' parameter. Default coverage is False or None.  `gdeltPyR` will pull the latest 15 minute interval for the current day or the last 15 minute interval for a historic day. | True or False or None           |
+| translation | (bool) - For GDELT 2.0, if the english or translated-to-english dataset should be downloaded                                                                                                                                                                      | True or False                   |
+| tables      | (string) - The specific GDELT table to pull.  The default table is the 'events' table.  See the [GDELT documentation page for more information](http://gdeltproject.org/data.html#documentation)                                                                  | 'events' or 'mentions' or 'gkg' |
+| output      | (string) - The output type for the results                                                                 | 'json' or 'csv' or 'gpd' |
 These parameter values can be mixed and matched to return the data you want.  the `coverage` parameter is used with GDELT version 2; when set to "True", the `gdeltPyR` will query all available 15 minute intervals for the dates passed.  For the current day, the query will return the most recent 15 minute interval. 
   
 *Facts*
@@ -113,6 +114,7 @@ These parameter values can be mixed and matched to return the data you want.  th
      *  1.0 posts the previous day's data at 6AM EST of next day (i.e. Monday's data will be available 6AM Tuesday EST)
 * GDELT 2.0 is updated every 15 minutes  
      *  2.0 has 'events','gkg', and 'mentions' tables
+     *  2.0 has a distinction between native english and translated-to-english news
      *  2.0 has more columns
 
 

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Basic Usage
     
     gd = gdelt.gdelt(version=2)
     
-    results = gd.Search(['2016 10 19','2016 10 22'],table='events',coverage=True)
+    results = gd.Search(['2016 10 19','2016 10 22'],table='events',coverage=True,translation=False)
 
     
 

--- a/gdelt/base.py
+++ b/gdelt/base.py
@@ -175,6 +175,8 @@ class gdelt(object):
             self.baseUrl = gdelt1url
         self.codes = codes
 
+        self.translation = None
+
     ###############################
     # Searcher function for GDELT
     ###############################
@@ -183,6 +185,7 @@ class gdelt(object):
                date,
                table='events',
                coverage=False,
+               translation=False,
                output=None,
                queryTime=datetime.datetime.now().strftime('%m-%d-%Y %H:%M:%S'),
                normcols=False
@@ -275,6 +278,11 @@ class gdelt(object):
             we pull every 15 minute interval for historical days and up to
             the most recent 15 minute interval for the current day, if that
             day is included.
+            
+        translation : bool, default: False
+            Whether or not to pull the translation database available from
+            version 2 of GDELT. If translation is True, the translated set
+            is downloaded, if set to False the english set is downloaded. 
 
         queryTime : datetime object, system generated
             This records the system time when gdeltPyR's query was executed,
@@ -359,6 +367,7 @@ class gdelt(object):
         baseUrl = self.baseUrl
         self.queryTime = queryTime
         self.table = table
+        self.translation = translation
         self.datesString = gdeltRangeString(dateRanger(self.date),
                                             version=version,
                                             coverage=self.coverage)
@@ -397,10 +406,10 @@ class gdelt(object):
         v2RangerNoCoverage = partial(gdeltRangeString, version=2,
                                      coverage=False)
         urlsv1gkg = partial(urlBuilder, version=1, table='gkg')
-        urlsv2mentions = partial(urlBuilder, version=2, table='mentions')
-        urlsv2events = partial(urlBuilder, version=2, table='events')
+        urlsv2mentions = partial(urlBuilder, version=2, table='mentions', translation=self.translation)
+        urlsv2events = partial(urlBuilder, version=2, table='events', translation=self.translation)
         urlsv1events = partial(urlBuilder, version=1, table='events')
-        urlsv2gkg = partial(urlBuilder, version=2, table='gkg')
+        urlsv2gkg = partial(urlBuilder, version=2, table='gkg', translation=self.translation)
 
         eventWork = partial(mp_worker, table='events')
         codeCams = partial(cameos, codes=codes)

--- a/gdelt/vectorizingFuncs.py
+++ b/gdelt/vectorizingFuncs.py
@@ -57,7 +57,7 @@ def downloadVectorizer(function, urlList):
     helper = np.vectorize(function)
     return pd.concat(helper(urlList).tolist()).reset_index(drop=True)
 
-def urlBuilder(dateString, version, table='events'):
+def urlBuilder(dateString, version, table='events', translation=False):
     """
     Takes date string from gdeltRange string and creates GDELT urls
 
@@ -84,9 +84,15 @@ def urlBuilder(dateString, version, table='events'):
     if table == "events":
         if version == 1:
             base += 'events/'
-        caboose = ".export.CSV.zip"
+        if not translation:
+            caboose = ".export.CSV.zip"
+        else:
+            caboose = ".translation.export.CSV.zip"
     elif table == "mentions":
-        caboose = ".mentions.CSV.zip"
+        if not translation:
+            caboose = ".mentions.CSV.zip"
+        else:
+            caboose = ".translation.mentions.CSV.zip"
     elif table == "gkg":
         if version == 1:
             base += 'gkg/'
@@ -116,7 +122,10 @@ def urlBuilder(dateString, version, table='events'):
             #                     ' than or equal to April 1 2013')
 
 
-        caboose = ".gkg.csv.zip"
+        if not translation:
+            caboose = ".gkg.csv.zip"
+        else:
+            caboose = ".translation.gkg.csv.zip"
     else:
         raise ValueError('You entered an incorrect GDELT table type.'
                          ' Choose between \"events\",\"mentions\",'

--- a/tests/test_urlBuilder.py
+++ b/tests/test_urlBuilder.py
@@ -40,6 +40,15 @@ class TestUrlBuilder(TestCase):
 
         return self.assertEqual(exp, urlbuilder_test, "Version 2 Url works.")
 
+    def test_urlbuilder_v2_translation(self):
+        date_sequence = '2016 10 01'
+        ranger_output = dateRanger(date_sequence)
+        gdeltstring_output = gdeltRangeString(ranger_output, version=2)
+        urlbuilder_test = urlBuilder(gdeltstring_output, version=2, translation=True)
+        exp = 'http://data.gdeltproject.org/gdeltv2/20161001234500.translation.export.CSV.zip'
+
+        return self.assertEqual(exp, urlbuilder_test, "Version 2 Url works.")
+
     def test_urlbuilder_v3(self):
         date_sequence = '2013 Mar 01'
         ranger_output = dateRanger(date_sequence)
@@ -70,7 +79,15 @@ class TestUrlBuilder(TestCase):
         gdeltstring_output = gdeltRangeString(ranger_output, version=2)
         urlbuilder_test = urlBuilder(gdeltstring_output, table='gkg', version=2)
         exp = 'http://data.gdeltproject.org/gdeltv2/20150401234500.gkg.csv.zip'
-        return self.assertEqual(exp, urlbuilder_test, "Version 1 Url works.")
+        return self.assertEqual(exp, urlbuilder_test, "Version 2 Url works.")
+
+    def test_urlbuilder_graph2_pass_translation(self):
+        date_sequence = '2015 Apr 01'
+        ranger_output = dateRanger(date_sequence)
+        gdeltstring_output = gdeltRangeString(ranger_output, version=2)
+        urlbuilder_test = urlBuilder(gdeltstring_output, table='gkg', version=2, translation=True)
+        exp = 'http://data.gdeltproject.org/gdeltv2/20150401234500.translation.gkg.csv.zip'
+        return self.assertEqual(exp, urlbuilder_test, "Version 2 Url works with translation.")
 
     def test_urlbuilder_events2_passlist(self):
         date_sequence = ['2015 Apr 01','2015 Apr 02']
@@ -79,6 +96,15 @@ class TestUrlBuilder(TestCase):
         urlbuilder_test = urlBuilder(gdeltstring_output, table='events', version=2)
         exp = np.sort(np.array(['http://data.gdeltproject.org/gdeltv2/20150401234500.export.CSV.zip',
                                 'http://data.gdeltproject.org/gdeltv2/20150402234500.export.CSV.zip']))
+        return np.testing.assert_array_equal(np.sort(np.array(urlbuilder_test)), np.sort(np.array(exp)))
+
+    def test_urlbuilder_events2_passlist_translation(self):
+        date_sequence = ['2015 Apr 01','2015 Apr 02']
+        ranger_output = dateRanger(date_sequence)
+        gdeltstring_output = gdeltRangeString(ranger_output, version=2)
+        urlbuilder_test = urlBuilder(gdeltstring_output, table='events', version=2, translation=True)
+        exp = np.sort(np.array(['http://data.gdeltproject.org/gdeltv2/20150401234500.translation.export.CSV.zip',
+                                'http://data.gdeltproject.org/gdeltv2/20150402234500.translation.export.CSV.zip']))
         return np.testing.assert_array_equal(np.sort(np.array(urlbuilder_test)), np.sort(np.array(exp)))
 
     def test_urlbuilder_events1_passlist(self):


### PR DESCRIPTION
Added a parameter `translation` to Seach and use it in `urlBuilder` to get paths to the translated files.

This fixes #26 .