### PR TITLE
Requirements that appear necessary for tests to pass. See Issue #55.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ requests>=2.11.1
 six>=1.10.0
 python-dateutil>=2.5.3
 beautifulsoup4
+pytest-cov
+geopandas
 
 # for Python 2.7 and 2.6 (environment marker support as of pip 6.0)
 futures ; python_version < '3.3'


### PR DESCRIPTION
geopandas is clearly needed although I'm not sure in which requirements file.
pytest-cov is less clear but probably wise to force-install in case it isn't.